### PR TITLE
fix: Resolver duplicidade ao criar uma nova categoria

### DIFF
--- a/src/domain/use_cases/categoria/categoria.use_case.spec.ts
+++ b/src/domain/use_cases/categoria/categoria.use_case.spec.ts
@@ -117,7 +117,7 @@ describe('Categoria Use case', () => {
 
   describe('Criar categoria', () => {
     it('Deve ser lançado um erro ao tentar criar uma categoria com um nome já registrado no sistema', async () => {
-      const categoriaDto = makeCriaCategoriaDTO('Categoria 1', 'Descrição 1');
+      const categoriaDto = makeCriaCategoriaDTO('lanche', 'lanche x tudo');
       jest
         .spyOn(categoriaRepository, 'buscarCategoriaPorNome')
         .mockReturnValue(Promise.resolve(categoriaModelMock));

--- a/src/domain/use_cases/categoria/categoria.use_case.ts
+++ b/src/domain/use_cases/categoria/categoria.use_case.ts
@@ -24,15 +24,18 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   async criarCategoria(
     categoria: CriaCategoriaDTO,
   ): Promise<HTTPResponse<CategoriaDTO>> {
-    const { nome, descricao } = categoria; // Desempacotando os valores do DTO
-
+    const categoriaEntity = new CategoriaEntity(
+      categoria.nome,
+      categoria.descricao,
+    );
     const buscaCategoria =
-      await this.categoriaRepository.buscarCategoriaPorNome(nome);
+      await this.categoriaRepository.buscarCategoriaPorNome(
+        categoriaEntity.getNome,
+      );
     if (buscaCategoria) {
       throw new CategoriaDuplicadaErro('Existe uma categoria com esse nome');
     }
 
-    const categoriaEntity = new CategoriaEntity(nome, descricao);
     const result =
       await this.categoriaRepository.criarCategoria(categoriaEntity);
 
@@ -51,23 +54,26 @@ export class CategoriaUseCase implements ICategoriaUseCase {
     categoriaId: string,
     categoria: AtualizaCategoriaDTO,
   ): Promise<HTTPResponse<CategoriaDTO>> {
-    const { nome, descricao } = categoria; // Desempacotando os valores do DTO
-
+    const categoriaEntity = new CategoriaEntity(
+      categoria.nome,
+      categoria.descricao,
+    );
     const buscaCategoriaPorId =
       await this.categoriaRepository.buscarCategoriaPorId(categoriaId);
     if (!buscaCategoriaPorId) {
       throw new CategoriaNaoLocalizadaErro('Categoria informada não existe');
     }
 
-    if (nome) {
+    if (categoriaEntity.getNome) {
       const buscaCategoriaPorNome =
-        await this.categoriaRepository.buscarCategoriaPorNome(nome);
+        await this.categoriaRepository.buscarCategoriaPorNome(
+          categoriaEntity.getNome,
+        );
       if (buscaCategoriaPorNome) {
         throw new CategoriaDuplicadaErro('Existe uma categoria com esse nome');
       }
     }
 
-    const categoriaEntity = new CategoriaEntity(nome, descricao);
     const result = await this.categoriaRepository.editarCategoria(
       categoriaId,
       categoriaEntity,


### PR DESCRIPTION
BUG: [Erro de validação de existencia ao criar e editar categoria](https://trello.com/c/guOXPzVs)

Estávamos com uma inconsistência ao tentar buscar uma categoria pois não estávamos "formatando" o nome da categoria antes de fazer a busca. Dado isso o retorno era que a categoria não existia e assim poderia ser criada novamente. 
Para resolução estamos criando a entidade categoria, onde a formatação é feita, antes de realizar a busca da mesma. Com isso a busca será  feita com o mesmo padrão salvo no banco.

![Correção criação categoria](https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend/assets/28732069/f346e5e5-024e-49f6-975e-a045288eb2a9)
