### PR TITLE
fix: Corrige "Cannot read properties of null" após merge com a main

### DIFF
--- a/src/domain/factories/pedido/pedido.dto.factory.ts
+++ b/src/domain/factories/pedido/pedido.dto.factory.ts
@@ -12,15 +12,11 @@ export class PedidoDTOFactory implements IPedidoDTOFactory {
     private readonly produtoDTOFactory: IProdutoDTOFactory,
     @Inject(IClienteDTOFactory)
     private readonly clienteDTOFactory: IClienteDTOFactory,
-  ) {}
+  ) { }
 
   async criarPedidoDTO(pedido: PedidoModel): Promise<PedidoDTO> {
     const itensPedido = await this.produtoDTOFactory.criarListaProdutoDTO(
       pedido.itensPedido,
-    );
-
-    const clienteDTO = await this.clienteDTOFactory.criarClienteDTO(
-      pedido.cliente,
     );
 
     const pedidoDTO = new PedidoDTO();
@@ -28,7 +24,13 @@ export class PedidoDTOFactory implements IPedidoDTOFactory {
     pedidoDTO.numeroPedido = pedido.numeroPedido;
     pedidoDTO.itensPedido = itensPedido;
     pedidoDTO.statusPedido = pedido.statusPedido;
-    pedidoDTO.cliente = clienteDTO;
+
+    if (pedido.cliente) {
+      pedidoDTO.cliente = await this.clienteDTOFactory.criarClienteDTO(
+        pedido.cliente,
+      );
+    }
+
     return pedidoDTO;
   }
 

--- a/src/domain/factories/produto/produto.dto.factory.ts
+++ b/src/domain/factories/produto/produto.dto.factory.ts
@@ -9,7 +9,7 @@ export class ProdutoDTOFactory implements IProdutoDTOFactory {
   constructor(
     @Inject(ICategoriaDTOFactory)
     private readonly categoriaDTOFactory: ICategoriaDTOFactory,
-  ) {}
+  ) { }
 
   async criarProdutoDTO(produto: ProdutoModel): Promise<ProdutoDTO> {
     const categoriaDTO = await this.categoriaDTOFactory.criarCategoriaDTO(
@@ -32,17 +32,19 @@ export class ProdutoDTOFactory implements IProdutoDTOFactory {
   ): Promise<ProdutoDTO[] | []> {
     const listaProdutosDTO = await Promise.all(
       produtos.map(async (produto: ProdutoModel) => {
-        const categoriaDTO = await this.categoriaDTOFactory.criarCategoriaDTO(
-          produto.categoria,
-        );
-
         const produtoDTO = new ProdutoDTO();
         produtoDTO.id = produto.id;
         produtoDTO.nome = produto.nome;
         produtoDTO.descricao = produto.descricao;
         produtoDTO.valorUnitario = produto.valorUnitario;
         produtoDTO.imagemUrl = produto.imagemUrl;
-        produtoDTO.categoria = categoriaDTO;
+
+        if (produtoDTO.categoria) {
+          produtoDTO.categoria = await this.categoriaDTOFactory.criarCategoriaDTO(
+            produto.categoria,
+          );
+        }
+
         return produtoDTO;
       }),
     );

--- a/src/domain/use_cases/pedido/pedido.use_case.ts
+++ b/src/domain/use_cases/pedido/pedido.use_case.ts
@@ -38,6 +38,8 @@ export class PedidoUseCase implements IPedidoUseCase {
     const qrData = await this.gatewayPagamentoService.criarPedido(pedidoEntity);
     const pedidoDTO = await this.pedidoDTOFactory.criarPedidoDTO(result);
 
+    pedidoDTO.qrCode = qrData;
+
     return {
       mensagem: 'Pedido criado com sucesso',
       body: pedidoDTO,

--- a/src/mocks/pedido.mock.ts
+++ b/src/mocks/pedido.mock.ts
@@ -85,6 +85,7 @@ const pedidoDTOMock = makePedidoDTO(
   [produtoDTOMock],
   pedidoModelMock.statusPedido,
   clienteDTOMock,
+  null
 );
 
 const pedidoTypeORMMock: jest.Mocked<Repository<PedidoModel>> = {


### PR DESCRIPTION
Correção para o erro "Cannot read properties of null" ao criar e consultar pedidos que apareceu após o merge.

ANTES DA CORREÇÃO

<img width="866" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend/assets/5115895/576fac17-b20f-426a-bd43-492256622f96">

DEPOIS DA CORREÇÃO

<img width="819" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend/assets/5115895/89d8b06d-e009-46e7-aab8-8acd1b791bfc">
